### PR TITLE
Removed warning for FTPClient hiding.

### DIFF
--- a/src/main/scala/uk/co/bbc/ftp/FTPClient.scala
+++ b/src/main/scala/uk/co/bbc/ftp/FTPClient.scala
@@ -1,8 +1,8 @@
 package uk.co.bbc.ftp
 
-import org.apache.commons.net.ftp.FTPClient
+import org.apache.commons.net.ftp.{FTPClient => ApacheFTPClient}
 
 object FTPClient {
   def apply (): FTP =
-    new FTP(new FTPClient)
+    new FTP(new ApacheFTPClient)
 }


### PR DESCRIPTION
#### Description
Apache's `FTPClient` is hidden by the local implementation and generates a compilation warning.
This pull request fixes it by renaming the import in the scope.